### PR TITLE
Fix Ericsson 2G external dag task

### DIFF
--- a/mediation/packages/bts/ericsson_cm.py
+++ b/mediation/packages/bts/ericsson_cm.py
@@ -98,7 +98,7 @@ class EricssonCM(object):
             1, -- 1- Ericsson, 2 - Huawei, 3 - ZTE, 4-Nokia
             t1."userLabel",
             t4.pk -- site primary key
-            FROM ericsson_cm_3g."UtranCell" t1
+            FROM ericsson_cm."UtranCell" t1
             INNER JOIN ericsson_bulkcm."NodeBFunction" t2 on t2."nodeBFunctionIubLink" = t1."utranCellIubLink"
             INNER JOIN live_network.nodes t3 on t3."name" = t1."MeContext_id" 
                     AND t3.vendor_pk = 1
@@ -144,7 +144,7 @@ class EricssonCM(object):
         now()::timestamp as date_added,
         now()::timestamp as date_modified
         FROM
-        ericsson_cm_2g."EXTERNAL_CELL" t1
+        ericsson_cm."EXTERNAL_CELL" t1
         LEFT JOIN live_network.nodes t2 ON t2."name" = t1."BSC_NAME"
         LEFT JOIN live_network.cells t3 on t3."name" = t1."CELL_NAME"
         LEFT JOIN live_network.gsm_external_cells t4 on t4."name" = t1."CELL_NAME" 
@@ -183,7 +183,7 @@ class EricssonCM(object):
         now()::timestamp as date_added,
         now()::timestamp as date_modified
         FROM
-        ericsson_cm_2g."UTRAN_EXTERNAL_CELL" t1
+        ericsson_cm."UTRAN_EXTERNAL_CELL" t1
         LEFT JOIN live_network.nodes t2 ON t2."name" = t1."BSC_NAME"
         LEFT JOIN live_network.cells t3 on t3."name" = t1."CELL_NAME"
         LEFT JOIN live_network.umts_external_cells t4 on t4."name" = t1."CELL_NAME" 
@@ -226,7 +226,7 @@ class EricssonCM(object):
         now()::timestamp as date_added,
         now()::timestamp as date_modified
         FROM
-        ericsson_cm_3g."ExternalGsmCell" t1
+        ericsson_cm."ExternalGsmCell" t1
         LEFT JOIN live_network.nodes t2 ON t2."name" = 'SubNetwork' and t2.vendor_pk = 1 and t2.tech_pk = 2
         LEFT JOIN live_network.cells t3 on t3."name" = t1."userLabel"
         LEFT JOIN live_network.gsm_external_cells t4 on t4."name" = t1."userLabel" 
@@ -265,7 +265,7 @@ class EricssonCM(object):
         now()::timestamp as date_added,
         now()::timestamp as date_modified
         FROM
-        ericsson_cm_3g."ExternalUtranCell" t1
+        ericsson_cm."ExternalUtranCell" t1
         LEFT JOIN live_network.nodes t2 ON t2."name" = 'SubNetwork' and t2.vendor_pk = 1 AND tech_pk = 2
         LEFT JOIN live_network.cells t3 on t3."name" = t1."userLabel"
         LEFT JOIN live_network.umts_external_cells t4 on t4."name" = t1."userLabel" 
@@ -300,7 +300,7 @@ class EricssonCM(object):
         now()::timestamp as date_added,
         now()::timestamp as date_modified
         FROM
-        ericsson_cm_3g."ExternalEUtranCellFDD" t1
+        ericsson_cm."ExternalEUtranCellFDD" t1
         LEFT JOIN live_network.cells t3 on t3."name" = t1."userLabel"
         LEFT JOIN live_network.lte_external_cells t4 on t4."name" = t1."userLabel" 
             AND t4.ci = t1."localCellId"::integer
@@ -338,7 +338,7 @@ class EricssonCM(object):
         now()::timestamp as date_added,
         now()::timestamp as date_modified
         FROM
-        ericsson_cm_3g."ExternalGsmCell" t1
+        ericsson_cm."ExternalGsmCell" t1
         LEFT JOIN live_network.nodes t2 ON t2."name" = 'SubNetwork' and t2.vendor_pk = 1 and t2.tech_pk = 3
         LEFT JOIN live_network.cells t3 on t3."name" = t1."userLabel"
         LEFT JOIN live_network.gsm_external_cells t4 on t4."name" = t1."userLabel" 
@@ -377,7 +377,7 @@ class EricssonCM(object):
         now()::timestamp as date_added,
         now()::timestamp as date_modified
         FROM
-        ericsson_cm_3g."ExternalUtranCell" t1
+        ericsson_cm."ExternalUtranCell" t1
         LEFT JOIN live_network.nodes t2 ON t2."name" = 'SubNetwork' and t2.vendor_pk = 1 AND tech_pk = 3
         LEFT JOIN live_network.cells t3 on t3."name" = t1."userLabel"
         LEFT JOIN live_network.umts_external_cells t4 on t4."name" = t1."userLabel" 
@@ -412,7 +412,7 @@ class EricssonCM(object):
         now()::timestamp as date_added,
         now()::timestamp as date_modified
         FROM
-        ericsson_cm_3g."ExternalEUtranCellFDD" t1
+        ericsson_cm."ExternalEUtranCellFDD" t1
         LEFT JOIN live_network.cells t3 on t3."name" = t1."userLabel"
         LEFT JOIN live_network.lte_external_cells t4 on t4."name" = t1."userLabel" 
             AND t4.ci = t1."localCellId"::integer

--- a/mediation/packages/bts/huawei_cm.py
+++ b/mediation/packages/bts/huawei_cm.py
@@ -350,15 +350,15 @@ class HuaweiCM(object):
                  0, -- system
                  0
                  FROM 
-                 huawei_cm_2g."G2GNCELL" t1
+                 huawei_cm."G2GNCELL" t1
                 --LOAD
                 INNER JOIN cm_loads t8 on t8.pk = t1."LOADID"
                 -- 
-                 INNER JOIN huawei_cm_2g."GCELL" t2 ON 
+                 INNER JOIN huawei_cm."GCELL" t2 ON 
                      t2."FILENAME" = t1."FILENAME" 
                      AND t2."LOADID" = t1."LOADID"
                      AND t1."SRC2GNCELLID" = t2."CELLID"
-                 LEFT JOIN huawei_cm_2g."GEXT2GCELL" t3 ON 
+                 LEFT JOIN huawei_cm."GEXT2GCELL" t3 ON 
                      t3."FILENAME"  = t1."FILENAME"
                      AND t3."LOADID" = t1."LOADID"
                      AND t3."EXT2GCELLID" = t1."NBR2GNCELLID"
@@ -432,7 +432,7 @@ class HuaweiCM(object):
                 -- SYS/NE
                 INNER JOIN huawei_cm."SYS" t10 ON t10."FILENAME" = t1."FILENAME" 
                     AND t10."LOADID" = t1."LOADID"
-                INNER JOIN huawei_cm_2g."GCELL" t2 ON 
+                INNER JOIN huawei_cm."GCELL" t2 ON 
                     t2."FILENAME" = t1."FILENAME" 
                     AND t2."LOADID" = t1."LOADID"
                     AND t1."SRC2GNCELLID" = t2."CELLID"
@@ -1147,7 +1147,7 @@ class HuaweiCM(object):
                     t5.pk = t4.site_pk 
                     AND t5.vendor_pk = 2 AND t5.tech_pk = 2
                 -- nbr-----------
-                LEFT JOIN huawei_cm_3g."UEXT2GCELL" t8 on 
+                LEFT JOIN huawei_cm."UEXT2GCELL" t8 on 
                     t8."FILENAME" = t1."FILENAME"
                     AND t1."GSMCELLINDEX" = t8."GSMCELLINDEX"
                 LEFT JOIN live_network.cells t6 ON 
@@ -1526,11 +1526,11 @@ class HuaweiCM(object):
                 0, -- system
                 0
                 FROM 
-                huawei_cm_4g."EUTRANINTRAFREQNCELL" t1
-                INNER JOIN huawei_cm_3g."UCELL" t2 on 
+                huawei_cm."EUTRANINTRAFREQNCELL" t1
+                INNER JOIN huawei_cm."UCELL" t2 on 
                     t2.neid  = t1.neid 
                     AND t1."CELLID" = t2."CELLID"
-                INNER JOIN huawei_cm_3g."UCELL" t3 on 
+                INNER JOIN huawei_cm."UCELL" t3 on 
                     t3.neid = t1.neid
                     AND t3."CELLID" = t1."NCELLID"
                 INNER JOIN live_network.cells t4 ON 
@@ -1540,7 +1540,7 @@ class HuaweiCM(object):
                     t5.pk = t4.site_pk 
                     AND t5.vendor_pk = 2 AND t5.tech_pk = 2
                 -- -----------
-                LEFT JOIN huawei_cm_3g."UEXT3GCELL" t8 on 
+                LEFT JOIN huawei_cm."UEXT3GCELL" t8 on 
                     t8.neid = t1.neid
                     AND t8."CELLID" = t1."NCELLID"
                 LEFT JOIN live_network.cells t6 ON 


### PR DESCRIPTION
There were references to ericsson_cm_2g. This is artifact from
the old loading method. All vendors have one schema for all
the MOs irrespective of technology